### PR TITLE
Util refactor

### DIFF
--- a/code/nlp_code.q
+++ b/code/nlp_code.q
@@ -52,8 +52,8 @@ compareDocToCentroid:{[centroid;doc]
 
 // @kind function
 // @category nlp
-// @fileoverview Find the cosine similarity between document and the 
-//   other documents in the corpus
+// @fileoverview Find the cosine similarity between one document and all the 
+//   other documents of the corpus
 // @param keywords {dict[]} A list of dictionaries of keywords and coefficients
 // @param idx {num} The index of the feature vector to compare to the rest of 
 //   the corpus
@@ -68,13 +68,13 @@ compareDocToCorpus:{[keywords;idx]
 // @param str1 {str;str[]} A string of text
 // @param str2 {str;str[]} A string of text
 // @returns {float} The Jaro-Winkler of two strings, between 0 and 1
-i.jaroWinkler:{[str1;str2]
+jaroWinkler:{[str1;str2]
   str1:lower str1;
   str2:lower str2;
   jaroScore:i.jaro[str1;str2];
-  $[0.7<jaroScore;
-    jaroScore+(sum mins(4#str1)~'4#str2)*.1*1-jaroScore;
-    jaroScore
+  jaroScore+$[0.7<jaroScore;
+    (sum mins(4#str1)~'4#str2)*.1*1-jaroScore;
+    0
     ]
   }
 

--- a/code/utils.q
+++ b/code/utils.q
@@ -13,7 +13,8 @@ i.bool:.p.import[`builtins]`:bool
 // @category nlpUtility
 // @fileoverview A fast way to sum a list of dictionaries in 
 //   certain cases
-// @param iter {long} The number of iterations
+// @param iter {long} The number of iterations. Note that within this
+//   library iter is set explicitly to 2 for all present invocations
 // @param dict {dict[]} A list of dictionaries
 // @returns {dict} The dictionary values summed together
 i.fastSum:{[iter;dict]
@@ -23,7 +24,7 @@ i.fastSum:{[iter;dict]
   // adds those groups.
   dictGroup:(ceiling sqrt count dict)cut dict;
   sum$[iter;.z.s iter-1;sum]each dictGroup
-  }2
+  }[2]
 
 // @private
 // @kind function
@@ -54,7 +55,8 @@ i.findRuns:{[array]
 // @private
 // @kind function
 // @category nlpUtility
-// @fileoverview Index of minimum element of a list
+// @fileoverview Index of the first occurrence of the minimum
+//   value of an array
 // @param array {num[]} Array of values 
 // @return {num} The index of the minimum element of the array
 i.minIndex:{[array]
@@ -64,7 +66,8 @@ i.minIndex:{[array]
 // @private
 // @kind function
 // @category nlpUtility
-// @fileoverview Index of maximum element of a list
+// @fileoverview Index of the first occurrence of the maximum
+//   value of the array
 // @param array {num[]} Array of values 
 // @return {num} The index of the maximum element of the array
 i.maxIndex:{[array]

--- a/code/utils.q
+++ b/code/utils.q
@@ -1,4 +1,5 @@
 \d .nlp
+\l p.q
 
 // @private
 // @kind function


### PR DESCRIPTION
* Reintroduction of p.q loading (embedPy was not being loaded by default -> issues with importing modules)
* `.nlp.i.jaroWinkler` definition should be `.nlp.jaroWinkler`
* Explicit note about fastSum in its current form only using 2 iterations at all times
* Minor caveat to imin/imax functionality as these will only return the first index of the min/max rather than all the indices